### PR TITLE
Custom ModDataContent for Fallout 4.

### DIFF
--- a/src/fallout4moddatacontent.h
+++ b/src/fallout4moddatacontent.h
@@ -1,0 +1,41 @@
+#ifndef FALLOUT4_MODDATACONTENT_H
+#define FALLOUT4_MODDATACONTENT_H
+
+#include <gamebryomoddatacontent.h>
+#include <ifiletree.h>
+
+class Fallout4ModDataContent : public GamebryoModDataContent {
+protected:
+  enum Fallout4Content {
+    CONTENT_MATERIAL = CONTENT_NEXT_VALUE
+  };
+
+public:
+  Fallout4ModDataContent(GameGamebryo const* gamePlugin) :
+    GamebryoModDataContent(gamePlugin)
+  {
+    m_Enabled[CONTENT_SKYPROC] = false;
+  }
+
+  std::vector<Content> getAllContents() const override
+  {
+    auto contents = GamebryoModDataContent::getAllContents();
+    contents.push_back(Content(CONTENT_MATERIAL, "Materials", ":/MO/gui/content/material"));
+    return contents;
+  }
+
+  std::vector<int> getContentsFor(
+    std::shared_ptr<const MOBase::IFileTree> fileTree) const override
+  {
+    auto contents = GamebryoModDataContent::getContentsFor(fileTree);
+    for (auto e : *fileTree) {
+      if (e->compare("materials") == 0) {
+        contents.push_back(CONTENT_MATERIAL);
+        break; // Early break if you have nothing else to check.
+      }
+    }
+    return contents;
+  }
+};
+
+#endif // FALLOUT4_MODDATACONTENT_H

--- a/src/gamefallout4.cpp
+++ b/src/gamefallout4.cpp
@@ -5,6 +5,7 @@
 #include "fallout4savegameinfo.h"
 #include "fallout4unmanagedmods.h"
 #include "fallout4moddatachecker.h"
+#include "fallout4moddatacontent.h"
 
 #include <pluginsetting.h>
 #include <executableinfo.h>
@@ -40,6 +41,7 @@ bool GameFallout4::init(IOrganizer *moInfo)
   registerFeature<DataArchives>(new Fallout4DataArchives(myGamesPath()));
   registerFeature<LocalSavegames>(new GamebryoLocalSavegames(myGamesPath(), "fallout4custom.ini"));
   registerFeature<ModDataChecker>(new Fallout4ModDataChecker(this));
+  registerFeature<ModDataContent>(new Fallout4ModDataContent(this));
   registerFeature<SaveGameInfo>(new Fallout4SaveGameInfo(this));
   registerFeature<GamePlugins>(new CreationGamePlugins(moInfo));
   registerFeature<UnmanagedMods>(new Fallout4UnmangedMods(this));


### PR DESCRIPTION
See ModOrganizer2/modorganizer-game_gamebryo#18

The icon for Material does not exist yet, but I don't want to have to make another PR for it. 