### PR TITLE
Do not create loadorder.txt when initializing profile

### DIFF
--- a/src/gamefallout4.cpp
+++ b/src/gamefallout4.cpp
@@ -113,7 +113,6 @@ void GameFallout4::initializeProfile(const QDir &path, ProfileSettings settings)
 {
   if (settings.testFlag(IPluginGame::MODS)) {
     copyToProfile(localAppFolder() + "/Fallout4", path, "plugins.txt");
-    copyToProfile(localAppFolder() + "/Fallout4", path, "loadorder.txt");
   }
 
   if (settings.testFlag(IPluginGame::CONFIGURATION)) {

--- a/src/gamefallout4.cpp
+++ b/src/gamefallout4.cpp
@@ -101,7 +101,7 @@ QString GameFallout4::description() const
 
 MOBase::VersionInfo GameFallout4::version() const
 {
-  return VersionInfo(1, 6, 0, VersionInfo::RELEASE_FINAL);
+  return VersionInfo(1, 7, 0, VersionInfo::RELEASE_FINAL);
 }
 
 QList<PluginSetting> GameFallout4::settings() const


### PR DESCRIPTION
The original intention behind loadorder.txt is to simply report the
load order of plugins to other applications. If the file is not a
known, good load order from MO2, it should not be used to change
the load order.